### PR TITLE
Tweak the release note label message

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ block-pr-with:
     - regex-label: "release-note/.*"
       # Helper message that will be set as a comment if the PR does not contain
       # the regex label
-      helper: "Release note label not set, please set the appropriate release note."
+      helper: "Please set the appropriate release note label."
       set-labels:
       # Labels that will automatically be set in case the PR does not contain
       # a label that match the regex above.

--- a/cmd/action_test.go
+++ b/cmd/action_test.go
@@ -78,7 +78,7 @@ func TestConfigParser(t *testing.T) {
 			LabelsUnset: []actions.PRLabelConfig{
 				{
 					RegexLabel: "release-note/.*",
-					Helper:     "Release note label not set, please set the appropriate release note.",
+					Helper:     "Please set the appropriate release note label.",
 					SetLabels: []string{
 						"dont-merge/needs-release-note",
 					},

--- a/test/config.yml
+++ b/test/config.yml
@@ -31,7 +31,7 @@ auto-label:
 block-pr-with:
   labels-unset:
   - regex-label: "release-note/.*"
-    helper: "Release note label not set, please set the appropriate release note."
+    helper: "Please set the appropriate release note label."
     set-labels:
     - "dont-merge/needs-release-note"
   labels-set:


### PR DESCRIPTION
Several first-time contributors (myself included) seem to understand the current message as "you need to set a release note in the original post for the bot to set a release note label" [1, 2]. This commit tweaks the message to try and avoid that.

1 - cilium/cilium#10552
2 - cilium/cilium#10454