### PR TITLE
.github: Rename maintainer's little helper's config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ in `github.com/cilium/cilium`
 
 ## Configuration
 
-Configuration needs to located at `.github/cilium-actions.yml`.
+Configuration needs to located at `.github/maintainers-little-helper.yml`.
 
 All the supported options are:
 


### PR DESCRIPTION
This pull request renames the config. file to better clarify its purpose.