### PR TITLE
Fix build by using v40 of go-github dep

### DIFF
--- a/cmd/handlers.go
+++ b/cmd/handlers.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	"github.com/cilium/github-actions/pkg/github"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 	"github.com/palantir/go-githubapp/githubapp"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"

--- a/pkg/github/assignees.go
+++ b/pkg/github/assignees.go
@@ -17,7 +17,7 @@ package github
 import (
 	"context"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type assignHandler func(ctx context.Context, owner, repo string, number int, assignees []string) (*gh.Issue, *gh.Response, error)

--- a/pkg/github/automerge.go
+++ b/pkg/github/automerge.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type AutoMerge struct {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/cilium/github-actions/pkg/jenkins"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 )

--- a/pkg/github/comments.go
+++ b/pkg/github/comments.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 
 	"github.com/cilium/github-actions/pkg/jenkins"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type MLHCommand string

--- a/pkg/github/commits.go
+++ b/pkg/github/commits.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 	"time"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type MsgInCommit struct {

--- a/pkg/github/handlers.go
+++ b/pkg/github/handlers.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/cilium/github-actions/pkg/jenkins"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type PRBlockerConfig struct {

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cilium/github-actions/pkg/jenkins"
 	"github.com/cilium/github-actions/pkg/progress"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 const (

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -17,7 +17,7 @@ package github
 import (
 	"context"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 // ParseGHLabels parses the github labels into a map of labels (a set)

--- a/pkg/github/mergeable.go
+++ b/pkg/github/mergeable.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 	"time"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type PRLabelConfig struct {

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 	"time"
 
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 type ErrProjectNotFound struct {

--- a/pkg/github/prs.go
+++ b/pkg/github/prs.go
@@ -19,7 +19,7 @@ import (
 	"regexp"
 
 	"github.com/cilium/github-actions/pkg/progress"
-	gh "github.com/google/go-github/v39/github"
+	gh "github.com/google/go-github/v40/github"
 )
 
 // GetPRsFailures returns a map of 'open' non-draft PRs Numbers that maps to


### PR DESCRIPTION
The build was failing with the following errors.

    CGO_ENABLED=0 GOOS=linux go build -mod=vendor -a -installsuffix cgo -o github-actions ./cmd/...
    # github.com/cilium/github-actions/cmd
    cmd/handlers.go:76:42: cannot use installCli (type *"github.com/google/go-github/v40/github".Client) as type *"github.com/google/go-github/v39/github".Client in argument to "github.com/cilium/github-actions/pkg/github".NewClientFromGHClient
    cmd/handlers.go:110:42: cannot use installCli (type *"github.com/google/go-github/v40/github".Client) as type *"github.com/google/go-github/v39/github".Client in argument to "github.com/cilium/github-actions/pkg/github".NewClientFromGHClient
    cmd/handlers.go:144:42: cannot use installCli (type *"github.com/google/go-github/v40/github".Client) as type *"github.com/google/go-github/v39/github".Client in argument to "github.com/cilium/github-actions/pkg/github".NewClientFromGHClient
    cmd/handlers.go:209:42: cannot use installCli (type *"github.com/google/go-github/v40/github".Client) as type *"github.com/google/go-github/v39/github".Client in argument to "github.com/cilium/github-actions/pkg/github".NewClientFromGHClient
    make: *** [Makefile:12: github-actions] Error 2

This pull request fixes it by using v40 of the go-github dependency wherever possible.