### PR TITLE
handler: implement checkrun handler

### DIFF
--- a/pkg/github/automerge.go
+++ b/pkg/github/automerge.go
@@ -53,7 +53,7 @@ func (c *Client) AutoMerge(
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	commit, _, err := c.GHCli.Repositories.GetCommit(ctx, owner, repoName, head.GetSHA(), &gh.ListOptions{})
+	commit, _, err := c.GHClient.Repositories.GetCommit(ctx, owner, repoName, head.GetSHA(), &gh.ListOptions{})
 	if err != nil {
 		return err
 	}
@@ -113,7 +113,7 @@ func (c *Client) AutoMerge(
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 
-		_, _, err = c.GHCli.PullRequests.RequestReviewers(ctx, owner, repoName, prNumber, gh.ReviewersRequest{
+		_, _, err = c.GHClient.PullRequests.RequestReviewers(ctx, owner, repoName, prNumber, gh.ReviewersRequest{
 			Reviewers: requestedReviews,
 		})
 		// We don't continue if we just have requested for new reviews
@@ -156,7 +156,7 @@ func (c *Client) AutoMerge(
 		// a PR review event (review != nil).
 		if _, ok := prLabels[cfg.Label]; ok || review != nil {
 			c.log.Info().Msg("Removing ready-to-merge label")
-			_, err := c.GHCli.Issues.RemoveLabelForIssue(
+			_, err := c.GHClient.Issues.RemoveLabelForIssue(
 				context.Background(), owner, repoName, prNumber, cfg.Label)
 			if err != nil && !IsNotFound(err) {
 				return err
@@ -169,7 +169,7 @@ func (c *Client) AutoMerge(
 	if false {
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		_, _, err = c.GHCli.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
+		_, _, err = c.GHClient.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
 			Body: func() *string { a := fmt.Sprintf("Setting %s to let a human merge this PR.", cfg.Label); return &a }(),
 		})
 		if err != nil {
@@ -179,7 +179,7 @@ func (c *Client) AutoMerge(
 
 	ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_, _, err = c.GHCli.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, []string{cfg.Label})
+	_, _, err = c.GHClient.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, []string{cfg.Label})
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (c *Client) getCIStatus(
 	cancels = append(cancels, cancel)
 	nextPage := 0
 
-	brProt, _, err := c.GHCli.Repositories.GetBranchProtection(ctx, owner, repoName, base.GetRef())
+	brProt, _, err := c.GHClient.Repositories.GetBranchProtection(ctx, owner, repoName, base.GetRef())
 	if err != nil {
 		return nil, err
 	}
@@ -230,7 +230,7 @@ func (c *Client) getCIStatus(
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		gs, resp, err := c.GHCli.Repositories.GetCombinedStatus(ctx, owner, repoName, head.GetSHA(), &gh.ListOptions{
+		gs, resp, err := c.GHClient.Repositories.GetCombinedStatus(ctx, owner, repoName, head.GetSHA(), &gh.ListOptions{
 			Page: nextPage,
 		})
 		if err != nil {
@@ -252,7 +252,7 @@ func (c *Client) getCIStatus(
 
 	nextPage = 0
 	for {
-		lc, resp, err := c.GHCli.Checks.ListCheckRunsForRef(ctx, owner, repoName, head.GetSHA(), &gh.ListCheckRunsOptions{
+		lc, resp, err := c.GHClient.Checks.ListCheckRunsForRef(ctx, owner, repoName, head.GetSHA(), &gh.ListCheckRunsOptions{
 			ListOptions: gh.ListOptions{
 				Page: nextPage,
 			},
@@ -327,7 +327,7 @@ func (c *Client) getReviews(owner string, repoName string, prNumber int) (map[st
 	for {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		reviews, resp, err := c.GHCli.PullRequests.ListReviews(ctx, owner, repoName, prNumber, &gh.ListOptions{
+		reviews, resp, err := c.GHClient.PullRequests.ListReviews(ctx, owner, repoName, prNumber, &gh.ListOptions{
 			Page: nextPage,
 		})
 
@@ -358,7 +358,7 @@ func (c *Client) getPendingReviews(owner string, repoName string, prNumber int) 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
 
-		reviewers, resp, err := c.GHCli.PullRequests.ListReviewers(ctx, owner, repoName, prNumber, &gh.ListOptions{
+		reviewers, resp, err := c.GHClient.PullRequests.ListReviewers(ctx, owner, repoName, prNumber, &gh.ListOptions{
 			Page: nextPage,
 		})
 		if err != nil {

--- a/pkg/github/client.go
+++ b/pkg/github/client.go
@@ -26,7 +26,7 @@ import (
 )
 
 type Client struct {
-	GHCli      *gh.Client
+	GHClient   *gh.Client
 	log        *zerolog.Logger
 	orgName    string
 	repoName   string
@@ -35,7 +35,7 @@ type Client struct {
 
 func NewClient(ghToken string, orgName, repo string, logger *zerolog.Logger) *Client {
 	return &Client{
-		GHCli: gh.NewClient(
+		GHClient: gh.NewClient(
 			oauth2.NewClient(
 				context.Background(),
 				oauth2.StaticTokenSource(
@@ -52,9 +52,9 @@ func NewClient(ghToken string, orgName, repo string, logger *zerolog.Logger) *Cl
 	}
 }
 
-func NewClientFromGHClient(ghCli *gh.Client, orgName, repo string, logger *zerolog.Logger) *Client {
+func NewClientFromGHClient(ghClient *gh.Client, orgName, repo string, logger *zerolog.Logger) *Client {
 	return &Client{
-		GHCli:    ghCli,
+		GHClient: ghClient,
 		log:      logger,
 		orgName:  orgName,
 		repoName: repo,
@@ -62,7 +62,7 @@ func NewClientFromGHClient(ghCli *gh.Client, orgName, repo string, logger *zerol
 }
 
 func (c *Client) GetConfigFile(owner, repoName, file, sha string) ([]byte, error) {
-	fileContent, _, _, err := c.GHCli.Repositories.GetContents(
+	fileContent, _, _, err := c.GHClient.Repositories.GetContents(
 		context.Background(),
 		owner,
 		repoName,
@@ -98,7 +98,7 @@ func (c *Client) GetFailedJenkinsURLs(parentCtx context.Context, owner, repoName
 	for {
 		ctx, cancel := context.WithTimeout(parentCtx, 30*time.Second)
 		cancels = append(cancels, cancel)
-		gs, resp, err := c.GHCli.Repositories.GetCombinedStatus(ctx, owner, repoName, sha, &gh.ListOptions{
+		gs, resp, err := c.GHClient.Repositories.GetCombinedStatus(ctx, owner, repoName, sha, &gh.ListOptions{
 			Page: nextPage,
 		})
 		if err != nil {

--- a/pkg/github/comments.go
+++ b/pkg/github/comments.go
@@ -37,14 +37,14 @@ var (
 // CommentAndOpenIssue creates a comment and (re-)opens a GH issue in case it is
 // closed.
 func (c *Client) CommentAndOpenIssue(ctx context.Context, owner, repo string, issueNumber int, body string) error {
-	_, _, err := c.GHCli.Issues.CreateComment(ctx, owner, repo, issueNumber, &gh.IssueComment{
+	_, _, err := c.GHClient.Issues.CreateComment(ctx, owner, repo, issueNumber, &gh.IssueComment{
 		Body: &body,
 	})
 	if err != nil {
 		return err
 	}
 
-	_, _, err = c.GHCli.Issues.Edit(ctx, owner, repo, issueNumber, &gh.IssueRequest{
+	_, _, err = c.GHClient.Issues.Edit(ctx, owner, repo, issueNumber, &gh.IssueRequest{
 		State: func() *string { a := "open"; return &a }(),
 	})
 
@@ -53,7 +53,7 @@ func (c *Client) CommentAndOpenIssue(ctx context.Context, owner, repo string, is
 
 // CreateIssue creates a new GH issue. Returns the issue number created.
 func (c *Client) CreateIssue(ctx context.Context, owner, repo string, title, body string, labels []string) (int, error) {
-	ghIssue, _, err := c.GHCli.Issues.Create(ctx, owner, repo, &gh.IssueRequest{
+	ghIssue, _, err := c.GHClient.Issues.Create(ctx, owner, repo, &gh.IssueRequest{
 		Title:  &title,
 		Body:   &body,
 		Labels: &labels,

--- a/pkg/github/commits.go
+++ b/pkg/github/commits.go
@@ -55,7 +55,7 @@ func (c *Client) commitContains(owner, repoName string, prNumber int, msg string
 			Page:    page,
 			PerPage: 10,
 		}
-		commits, resp, err := c.GHCli.PullRequests.ListCommits(ctx, owner, repoName, prNumber, opts)
+		commits, resp, err := c.GHClient.PullRequests.ListCommits(ctx, owner, repoName, prNumber, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -90,7 +90,7 @@ func (c *Client) CommitContains(msgsInCommit []MsgInCommit, owner, repoName stri
 			for _, lbl := range msgRequired.SetLabels {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, err := c.GHCli.Issues.RemoveLabelForIssue(ctx, owner, repoName, prNumber, lbl)
+				_, err := c.GHClient.Issues.RemoveLabelForIssue(ctx, owner, repoName, prNumber, lbl)
 				if err != nil && !IsNotFound(err) {
 					return err
 				}
@@ -109,7 +109,7 @@ func (c *Client) CommitContains(msgsInCommit []MsgInCommit, owner, repoName stri
 		comment = fmt.Sprintf(comment, strings.Join(commits, ", "))
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		_, _, err = c.GHCli.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
+		_, _, err = c.GHClient.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
 			Body: &comment,
 		})
 		if err != nil {
@@ -117,7 +117,7 @@ func (c *Client) CommitContains(msgsInCommit []MsgInCommit, owner, repoName stri
 		}
 		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		_, _, err = c.GHCli.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, msgRequired.SetLabels)
+		_, _, err = c.GHClient.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, msgRequired.SetLabels)
 		if err != nil {
 			return err
 		}

--- a/pkg/github/issues.go
+++ b/pkg/github/issues.go
@@ -54,7 +54,7 @@ func (c *Client) GetFlakeIssues(ctx context.Context, owner, repo, creator string
 			return nil, ctx.Err()
 		default:
 		}
-		ghIssues, resp, err := c.GHCli.Issues.ListByRepo(ctx, owner, repo, &gh.IssueListByRepoOptions{
+		ghIssues, resp, err := c.GHClient.Issues.ListByRepo(ctx, owner, repo, &gh.IssueListByRepoOptions{
 			State:  "open",
 			Labels: labels,
 			ListOptions: gh.ListOptions{
@@ -91,7 +91,7 @@ func (c *Client) GetFlakeIssues(ctx context.Context, owner, repo, creator string
 		}
 
 		// Get all GH issues created by MLH since it's easier to parse them.
-		ghIssues, resp, err := c.GHCli.Issues.ListByRepo(ctx, owner, repo, &gh.IssueListByRepoOptions{
+		ghIssues, resp, err := c.GHClient.Issues.ListByRepo(ctx, owner, repo, &gh.IssueListByRepoOptions{
 			State:   "all",
 			Creator: creator,
 			Labels:  labels,
@@ -151,7 +151,7 @@ func (c *Client) findDupIssue(ctx context.Context, owner string, repo string, gh
 			return 0, ctx.Err()
 		default:
 		}
-		ghIssues, resp, err := c.GHCli.Issues.ListComments(ctx, owner, repo, ghIssueNumber, &gh.IssueListCommentsOptions{
+		ghIssues, resp, err := c.GHClient.Issues.ListComments(ctx, owner, repo, ghIssueNumber, &gh.IssueListCommentsOptions{
 			ListOptions: gh.ListOptions{
 				Page: nextPage,
 			},

--- a/pkg/github/labels.go
+++ b/pkg/github/labels.go
@@ -50,7 +50,7 @@ func (c *Client) AutoLabel(labels []string, owner string, repoName string, prNum
 		return nil
 	}
 
-	_, _, err := c.GHCli.Issues.AddLabelsToIssue(
+	_, _, err := c.GHClient.Issues.AddLabelsToIssue(
 		context.Background(), owner, repoName, prNumber, labels)
 	return err
 }

--- a/pkg/github/mergeable.go
+++ b/pkg/github/mergeable.go
@@ -76,7 +76,7 @@ func (c *Client) BlockPRWith(blockPRConfig BlockPRWith, owner, repoName string, 
 			for _, lbl := range lblsUnset.SetLabels {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, err := c.GHCli.Issues.RemoveLabelForIssue(ctx, owner, repoName, prNumber, lbl)
+				_, err := c.GHClient.Issues.RemoveLabelForIssue(ctx, owner, repoName, prNumber, lbl)
 				if err != nil && !IsNotFound(err) {
 					return false, nil, err
 				}
@@ -91,7 +91,7 @@ func (c *Client) BlockPRWith(blockPRConfig BlockPRWith, owner, repoName string, 
 			if lblsUnset.Helper != "" && !subslice(lblsUnset.SetLabels, prLabels) {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, _, err := c.GHCli.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
+				_, _, err := c.GHClient.Issues.CreateComment(ctx, owner, repoName, prNumber, &gh.IssueComment{
 					Body: &lblsUnset.Helper,
 				})
 				if err != nil {
@@ -101,7 +101,7 @@ func (c *Client) BlockPRWith(blockPRConfig BlockPRWith, owner, repoName string, 
 			if len(lblsUnset.SetLabels) != 0 {
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, _, err := c.GHCli.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, lblsUnset.SetLabels)
+				_, _, err := c.GHClient.Issues.AddLabelsToIssue(ctx, owner, repoName, prNumber, lblsUnset.SetLabels)
 				if err != nil {
 					return false, nil, err
 				}
@@ -170,7 +170,7 @@ func (c *Client) UpdateMergeabilityCheck(
 	cancels = append(cancels, cancel)
 	nextPage := 0
 	for {
-		lc, resp, err := c.GHCli.Checks.ListCheckRunsForRef(ctx, owner, repoName, head.GetSHA(), &gh.ListCheckRunsOptions{
+		lc, resp, err := c.GHClient.Checks.ListCheckRunsForRef(ctx, owner, repoName, head.GetSHA(), &gh.ListCheckRunsOptions{
 			CheckName: func() *string { a := checkerName; return &a }(),
 			ListOptions: gh.ListOptions{
 				Page: nextPage,
@@ -185,7 +185,7 @@ func (c *Client) UpdateMergeabilityCheck(
 					if pr.GetNumber() == prNumber {
 						ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 						cancels = append(cancels, cancel)
-						_, _, err := c.GHCli.Checks.UpdateCheckRun(ctx, owner, repoName, cr.GetID(), gh.UpdateCheckRunOptions{
+						_, _, err := c.GHClient.Checks.UpdateCheckRun(ctx, owner, repoName, cr.GetID(), gh.UpdateCheckRunOptions{
 							Name:       checkerName,
 							ExternalID: head.SHA,
 							Status:     func() *string { a := "completed"; return &a }(),
@@ -223,7 +223,7 @@ func (c *Client) UpdateMergeabilityCheck(
 		case IsNotFound(err):
 			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			cancels = append(cancels, cancel)
-			_, _, err := c.GHCli.Checks.CreateCheckRun(ctx, owner, repoName, gh.CreateCheckRunOptions{
+			_, _, err := c.GHClient.Checks.CreateCheckRun(ctx, owner, repoName, gh.CreateCheckRunOptions{
 				Name:       checkerName,
 				HeadSHA:    head.GetSHA(),
 				ExternalID: head.SHA,

--- a/pkg/github/projects.go
+++ b/pkg/github/projects.go
@@ -65,7 +65,7 @@ func (c *Client) getProjectID(owner, repoName, projURL string) (int64, error) {
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		projects, resp, err := c.GHCli.Repositories.ListProjects(ctx, owner, repoName, plo)
+		projects, resp, err := c.GHClient.Repositories.ListProjects(ctx, owner, repoName, plo)
 		if err != nil {
 			return 0, err
 		}
@@ -106,7 +106,7 @@ func (c *Client) GetColumnID(owner, repoName string, project Project) (int64, in
 		}
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		columns, resp, err := c.GHCli.Projects.ListProjectColumns(ctx, projectID, lo)
+		columns, resp, err := c.GHClient.Projects.ListProjectColumns(ctx, projectID, lo)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -134,7 +134,7 @@ func (c *Client) PutPRInProject(owner, repoName string, prID int64, project Proj
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	_, _, err = c.GHCli.Projects.CreateProjectCard(ctx, columnID, &gh.ProjectCardOptions{
+	_, _, err = c.GHClient.Projects.CreateProjectCard(ctx, columnID, &gh.ProjectCardOptions{
 		ContentID:   prID,
 		ContentType: "PullRequest",
 	})
@@ -179,7 +179,7 @@ func (c *Client) FindPRInProject(owner, repoName string, prNumber int, project P
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		cancels = append(cancels, cancel)
-		projectCards, resp, err := c.GHCli.Projects.ListProjectCards(ctx, columnID, pclo)
+		projectCards, resp, err := c.GHClient.Projects.ListProjectCards(ctx, columnID, pclo)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -213,7 +213,7 @@ func (c *Client) GetOrCreateColumnID(owner, repoName string, proj Project) (int6
 	}).Msg("Column not found in project")
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	column, _, err := c.GHCli.Projects.CreateProjectColumn(ctx, projectID, &gh.ProjectColumnOptions{
+	column, _, err := c.GHClient.Projects.CreateProjectColumn(ctx, projectID, &gh.ProjectColumnOptions{
 		Name: proj.ColumnName,
 	})
 	if err != nil {
@@ -303,7 +303,7 @@ func (c *Client) SyncPRProjects(
 				if columnID != cardColumnID {
 					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 					cancels = append(cancels, cancel)
-					_, err = c.GHCli.Projects.MoveProjectCard(ctx, cardID, &gh.ProjectCardMoveOptions{
+					_, err = c.GHClient.Projects.MoveProjectCard(ctx, cardID, &gh.ProjectCardMoveOptions{
 						Position: "top",
 						ColumnID: columnID,
 					})
@@ -315,7 +315,7 @@ func (c *Client) SyncPRProjects(
 				// card was not found so we have to create it!
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, _, err := c.GHCli.Projects.CreateProjectCard(ctx, columnID, &gh.ProjectCardOptions{
+				_, _, err := c.GHClient.Projects.CreateProjectCard(ctx, columnID, &gh.ProjectCardOptions{
 					ContentID:   prID,
 					ContentType: "PullRequest",
 				})
@@ -343,7 +343,7 @@ func (c *Client) SyncPRProjects(
 				}
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				cancels = append(cancels, cancel)
-				_, err = c.GHCli.Projects.DeleteProjectCard(ctx, cardID)
+				_, err = c.GHClient.Projects.DeleteProjectCard(ctx, cardID)
 				if err != nil && !IsNotFound(err) {
 					return err
 				}

--- a/pkg/github/prs.go
+++ b/pkg/github/prs.go
@@ -33,7 +33,7 @@ func (c *Client) GetPRsFailures(ctx context.Context, base string) (map[int][]str
 			return nil, ctx.Err()
 		default:
 		}
-		prs, resp, err := c.GHCli.PullRequests.List(ctx, c.orgName, c.repoName, &gh.PullRequestListOptions{
+		prs, resp, err := c.GHClient.PullRequests.List(ctx, c.orgName, c.repoName, &gh.PullRequestListOptions{
 			State: "open",
 			Base:  base,
 			ListOptions: gh.ListOptions{
@@ -80,7 +80,7 @@ func (c *Client) GetPRFailure(ctx context.Context, pr *gh.PullRequest) ([]string
 
 // GetPRFailures gets the jenkins URL failures of the given PR number.
 func (c *Client) GetPRFailures(ctx context.Context, prNumber int) ([]string, error) {
-	pr, _, err := c.GHCli.PullRequests.Get(ctx, c.orgName, c.repoName, prNumber)
+	pr, _, err := c.GHClient.PullRequests.Get(ctx, c.orgName, c.repoName, prNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +97,7 @@ func (c *Client) getPRTriggerComment(ctx context.Context, orgName, repo string, 
 			return nil, ctx.Err()
 		default:
 		}
-		comments, resp, err := c.GHCli.Issues.ListComments(ctx, orgName, repo, prNumber, &gh.IssueListCommentsOptions{
+		comments, resp, err := c.GHClient.Issues.ListComments(ctx, orgName, repo, prNumber, &gh.IssueListCommentsOptions{
 			ListOptions: gh.ListOptions{
 				Page: nextPage,
 			},
@@ -127,14 +127,14 @@ func (c *Client) getPRTriggerComment(ctx context.Context, orgName, repo string, 
 }
 
 func (c *Client) createComment(ctx context.Context, orgName, repo string, number int, body string) error {
-	_, _, err := c.GHCli.Issues.CreateComment(ctx, orgName, repo, number, &gh.IssueComment{
+	_, _, err := c.GHClient.Issues.CreateComment(ctx, orgName, repo, number, &gh.IssueComment{
 		Body: &body,
 	})
 	return err
 }
 
 func (c *Client) editComment(ctx context.Context, orgName, repo string, commentID int64, body string) error {
-	_, _, err := c.GHCli.Issues.EditComment(ctx, orgName, repo, commentID, &gh.IssueComment{
+	_, _, err := c.GHClient.Issues.EditComment(ctx, orgName, repo, commentID, &gh.IssueComment{
 		Body: &body,
 	})
 	return err


### PR DESCRIPTION
Currently we're triggering auto-close (labelling with `ready-to-merge`) on PullRequestEvent, PullRequestReviewEvent and StatusEvent. We're missing events where GitHub checks are completed but all other preconditions are already met.

Therefore, this PR registers and implements a GitHub event handler for the event type `check-run`. Its implementation triggers the automerge functionality.