### PR TITLE
regexp for require msgs in commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,4 +14,5 @@ github-actions:
 local: github-actions
 	strip github-actions
 
-clean: rm -fr github-actions
+clean:
+	rm -fr github-actions

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ move-to-projects-for-labels-xored:
       column: "Backport done to v1.5"
 # Require msg to be presented in all commits from the given PR
 require-msgs-in-commit:
+    # the expected string to be found in the commit. Alternatively you can
+    # match the commit against a regular expression with regexpMsg instead.
   - msg: "Signed-off-by"
     # Helper message that will be set as a comment if the PR does not contain
     # a the required msg in the commit message.

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -101,6 +101,11 @@ func runClient() {
 		ghClient = github.NewClient(os.Getenv("GITHUB_TOKEN"), orgName, repoName, zerolog.Ctx(globalCtx))
 
 		if prNumber != 0 {
+			err := ghClient.CommitContains(cfg.RequireMsgsInCommit, orgName, repoName, prNumber)
+			if err != nil {
+				panic(err)
+			}
+
 			ctx := context.WithValue(globalCtx, "include-draft", true)
 			prJenkinsURLFail, err := ghClient.GetPRFailures(ctx, prNumber)
 			if err != nil {

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -43,7 +43,7 @@ func init() {
 	flag.StringVar(&orgName, "org", "cilium", "GitHub organization name (for client-mode)")
 	flag.StringVar(&repoName, "repo", "cilium", "GitHub organization name (for client-mode)")
 	flag.IntVar(&prNumber, "pr", 0, "PR to check for flakes (for client-mode)")
-	flag.StringVar(&baseBranch, "branch", "master", "Base branch name (for client-mode)")
+	flag.StringVar(&baseBranch, "branch", "main", "Base branch name (for client-mode)")
 	flag.StringVar(&config, "config", "", "Flake config file (for client-mode)")
 	flag.BoolVar(&clientMode, "client-mode", false, "Runs MLH in client mode (useful for development)")
 	flag.Parse()


### PR DESCRIPTION
Add `regexpMsg` to `require-msgs-in-commit`, a regular expression alternative to `msg`. Also brings client mode support for `require-msgs-in-commit` on the way so I could manually test the patch.

## client mode tests

[Got a complain](https://github.com/kaworu/cilium/pull/287#issuecomment-1695267034) when checking for a missing `msg`:

```console
% cat check-msg-for-co-authored-by.yaml
require-msgs-in-commit:
  - msg: "Co-authored-by"
    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
    set-labels:
      - "dont-merge/needs-sign-off"
% ./github-actions -client-mode -org kaworu -repo cilium -branch master -pr 287 -config check-msg-for-co-authored-by.yaml
```

No complain on https://github.com/kaworu/cilium/pull/283 for an existing `msg`:

```console
% cat check-msg-for-signed-off-by.yaml
require-msgs-in-commit:
  - msg: "Signed-off-by"
    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
    set-labels:
      - "dont-merge/needs-sign-off"
% ./github-actions -client-mode -org kaworu -repo cilium -branch master -pr 283 -config check-msg-for-signed-off-by.yaml
```

Got an error when neither `msg` or `regexpMsg` is configured:

```console
% cat check-none.yaml
require-msgs-in-commit:
  - helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
    set-labels:
      - "dont-merge/needs-sign-off"
% ./github-actions -client-mode -org kaworu -repo cilium -branch master -pr 281 -config check-none.yaml
Getting PRs from GH
panic: no msg or regexpMsg configured

goroutine 1 [running]:
main.runClient()
	/home/alex/go/src/github.com/cilium/github-actions/cmd/client.go:106 +0x748
main.main()
	/home/alex/go/src/github.com/cilium/github-actions/cmd/main.go:34 +0x18
```

[Complains about no `regexpMsg` match](https://github.com/kaworu/cilium/pull/280#issuecomment-1695276228):

```console
% cat check-regexpmsg-for-co-authored-by.yaml
require-msgs-in-commit:
  - regexpMsg: "(?m)^Co-authored-by:"
    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
    set-labels:
      - "dont-merge/needs-sign-off"
% ./github-actions -client-mode -org kaworu -repo cilium -branch master -pr 280 -config check-regexpmsg-for-co-authored-by.yaml
```

No complain on https://github.com/kaworu/cilium/pull/277 when `regexpMsg` matches:

```console
% cat check-regexpmsg-for-signed-off-by.yaml
require-msgs-in-commit:
  - regexpMsg: "(?m)^Signed-off-by:"
    helper: "https://docs.cilium.io/en/stable/contributing/contributing/#developer-s-certificate-of-origin"
    set-labels:
      - "dont-merge/needs-sign-off"
% ./github-actions -client-mode -org kaworu -repo cilium -branch master -pr 277 -config check-regexpmsg-for-signed-off-by.yaml

```